### PR TITLE
Donut tags

### DIFF
--- a/app/controllers/donut_tags_controller.rb
+++ b/app/controllers/donut_tags_controller.rb
@@ -10,6 +10,8 @@ class DonutTagsController < ApplicationController
 
     if @donut_tag.save
       redirect_to bakery_path
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/donut_tags_controller.rb
+++ b/app/controllers/donut_tags_controller.rb
@@ -1,0 +1,25 @@
+class DonutTagsController < ApplicationController
+  before_action :set_donut, only: [:new, :create]
+  def new
+    @donut_tag = DonutTag.new()
+  end
+
+  def create
+    @donut_tag = DonutTag.new(donut_tag_params)
+    @donut_tag.donut = @donut
+
+    if @donut_tag.save
+      redirect_to bakery_path
+    end
+  end
+
+  private
+
+  def set_donut
+    @donut = Donut.find(params[:donut_id])
+  end
+
+  def donut_tag_params
+    params.require(:donut_tag).permit(:tag_id, :donut_id)
+  end
+end

--- a/app/controllers/donut_tags_controller.rb
+++ b/app/controllers/donut_tags_controller.rb
@@ -1,5 +1,7 @@
 class DonutTagsController < ApplicationController
   before_action :set_donut, only: [:new, :create]
+  before_action :set_donut_tag, only: [:destroy]
+
   def new
     @donut_tag = DonutTag.new()
   end
@@ -15,10 +17,19 @@ class DonutTagsController < ApplicationController
     end
   end
 
+  def destroy
+    @donut_tag.destroy
+    redirect_to bakery_path
+  end
+
   private
 
   def set_donut
     @donut = Donut.find(params[:donut_id])
+  end
+
+  def set_donut_tag
+    @donut_tag = DonutTag.find(params[:id])
   end
 
   def donut_tag_params

--- a/app/models/donut.rb
+++ b/app/models/donut.rb
@@ -2,6 +2,8 @@ class Donut < ApplicationRecord
   belongs_to :user
   has_many :reviews, dependent: :destroy
   has_many :orders
+  has_many :donut_tags, dependent: :destroy
+  has_many :tags, through: :donut_tags
   has_one_attached :photo
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/donut_tag.rb
+++ b/app/models/donut_tag.rb
@@ -1,0 +1,6 @@
+class DonutTag < ApplicationRecord
+  belongs_to :donut
+  belongs_to :tag
+
+  validates :tag, uniqueness: { scope: :donut, message: "Already added" }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :donut_tags, dependent: :destroy
+  has_many :donuts, through: :donut_tags
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,6 @@
 class Tag < ApplicationRecord
   has_many :donut_tags, dependent: :destroy
   has_many :donuts, through: :donut_tags
+
+  validates :name, uniqueness: true
 end

--- a/app/views/donut_tags/_form.html.erb
+++ b/app/views/donut_tags/_form.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for [donut, donut_tag] do |f| %>
+  <div class='d-flex'>
+    <%= f.association :tag, label: false, prompt: "Select a tag" %>
+    <%= f.submit "Add tag", style: 'height: 38px;' %>
+  </div>
+<% end %>

--- a/app/views/donut_tags/new.html.erb
+++ b/app/views/donut_tags/new.html.erb
@@ -1,0 +1,5 @@
+<div class='container'>
+  <h2>Add tag to donut</h2>
+  <%= render "form", donut: @donut, donut_tag: @donut_tag %>
+  <p><%= link_to "Back", bakery_path %></p>
+</div>

--- a/app/views/pages/bakery.html.erb
+++ b/app/views/pages/bakery.html.erb
@@ -216,9 +216,11 @@
                   </div>
                 </div>
               </li>
+              <% donut.donut_tags.each do |donut_tag| %>
+                <span><%= donut_tag.tag.name %></span>
+                <% end %>
 
-
-
+              <li class="list-group-item"><%= link_to "Add tag", donut_donut_tags_path(donut)#new %></li>
 
               <li class="list-group-item"><%= link_to "Edit Details", edit_donut_path(donut) %></li>
             </ul>

--- a/app/views/pages/bakery.html.erb
+++ b/app/views/pages/bakery.html.erb
@@ -216,11 +216,27 @@
                   </div>
                 </div>
               </li>
-              <% donut.donut_tags.each do |donut_tag| %>
-                <span><%= donut_tag.tag.name %></span>
-                <% end %>
 
-              <li class="list-group-item"><%= link_to "Add tag", new_donut_donut_tag_path(donut) %></li>
+              <li class="list-group-item">
+                <div class="nav-link dropdown">
+                  <span class="avatar dropdown-toggle" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Tags
+                  </span>
+                  <div class="dropdown-menu dropdown-menu-start" aria-labelledby="navbarDropdown">
+                    <div class="container" style="width: 250px;">
+                      <%= render "donut_tags/form", donut: donut, donut_tag: DonutTag.new %>
+                    </div>
+                  </div>
+                </div>
+
+                <% donut.donut_tags.each do |donut_tag| %>
+                  <%= donut_tag.tag.name %><%= link_to "X", donut_tag_path(donut_tag), data: {
+                                              turbo_method: :delete,
+                                              turbo_confirm: "Are you sure you want to remove your #{donut_tag.tag.name} tag?"
+                                              }
+                                            %><br>
+                <% end %>
+              </li>
 
               <li class="list-group-item"><%= link_to "Edit Details", edit_donut_path(donut) %></li>
             </ul>

--- a/app/views/pages/bakery.html.erb
+++ b/app/views/pages/bakery.html.erb
@@ -230,7 +230,7 @@
                 </div>
 
                 <% donut.donut_tags.each do |donut_tag| %>
-                  <%= donut_tag.tag.name %><%= link_to "X", donut_tag_path(donut_tag), data: {
+                  <%= donut_tag.tag.name %> <%= link_to "X", donut_tag_path(donut_tag), data: {
                                               turbo_method: :delete,
                                               turbo_confirm: "Are you sure you want to remove your #{donut_tag.tag.name} tag?"
                                               }

--- a/app/views/pages/bakery.html.erb
+++ b/app/views/pages/bakery.html.erb
@@ -220,7 +220,7 @@
                 <span><%= donut_tag.tag.name %></span>
                 <% end %>
 
-              <li class="list-group-item"><%= link_to "Add tag", donut_donut_tags_path(donut)#new %></li>
+              <li class="list-group-item"><%= link_to "Add tag", new_donut_donut_tag_path(donut) %></li>
 
               <li class="list-group-item"><%= link_to "Edit Details", edit_donut_path(donut) %></li>
             </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
     resources :donut_tags, only: [:new, :create]
   end
 
+  resources :donut_tags, only: [:destroy]
+
   resources :orders, only: [:index, :show]
 
   get :account, to: "pages#account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,16 @@
 Rails.application.routes.draw do
   devise_for :users
+
   root to: "pages#home"
+
   resources :donuts, only: [:index, :show, :new, :create, :edit, :update] do
     resources :orders, only: [:new, :create, :new, :update]
     resources :reviews, only: [:create]
+    resources :donut_tags, only: [:new, :create]
   end
+
   resources :orders, only: [:index, :show]
+
   get :account, to: "pages#account"
   get :bakery, to: "pages#bakery"
   get :archived, to: "pages#archived"

--- a/db/migrate/20230217105756_create_tags.rb
+++ b/db/migrate/20230217105756_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230217110124_create_donut_tags.rb
+++ b/db/migrate/20230217110124_create_donut_tags.rb
@@ -1,0 +1,10 @@
+class CreateDonutTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :donut_tags do |t|
+      t.references :donut, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_210121) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_17_110124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_210121) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "donut_tags", force: :cascade do |t|
+    t.bigint "donut_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["donut_id"], name: "index_donut_tags_on_donut_id"
+    t.index ["tag_id"], name: "index_donut_tags_on_tag_id"
   end
 
   create_table "donuts", force: :cascade do |t|
@@ -82,6 +91,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_210121) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -106,6 +121,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_210121) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "donut_tags", "donuts"
+  add_foreign_key "donut_tags", "tags"
   add_foreign_key "donuts", "users"
   add_foreign_key "orders", "donuts"
   add_foreign_key "orders", "users"

--- a/test/controllers/donut_tags_controller_test.rb
+++ b/test/controllers/donut_tags_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DonutTagsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/donut_tag_test.rb
+++ b/test/models/donut_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DonutTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Creates Tag & DonutTag models

Tags are empty and will need to be created in the console:
Tag.create!(name: "gluten free")
Tag.create!(name: "vegetarian")
Tag.create!(name: "vegan")
Tag.create!(name: "low fat")

Adds new tag option to Baker donut view in donut page with option to destroy tag.
Needs tags to be styled and added to donut index and show pages.

Needs to sort redirect if no tag option is selected or if an existing tag option is selected - currently sends user to the new donut_tag view (to be removed)
